### PR TITLE
Fixing stepheight in additional places.

### DIFF
--- a/src/main/java/am2/entity/EntitySpellEffect.java
+++ b/src/main/java/am2/entity/EntitySpellEffect.java
@@ -117,7 +117,7 @@ public class EntitySpellEffect extends Entity{
 		this.setRotation(rotation, 0);
 		this.dataManager.set(WATCHER_TYPE, TYPE_WAVE);
 		this.moveSpeed = speed;
-		this.stepHeight = 0.5f;
+		this.stepHeight = 0.6f;
 		maxTicksToEffect_wall = 1;
 	}
 

--- a/src/main/java/am2/handler/EntityHandler.java
+++ b/src/main/java/am2/handler/EntityHandler.java
@@ -275,7 +275,7 @@ public class EntityHandler {
 		if (ArmorHelper.isInfusionPreset(player.getItemStackFromSlot(EntityEquipmentSlot.LEGS), GenericImbuement.stepAssist)){
 			player.stepHeight = 1.0111f;
 		}else if (player.stepHeight == 1.0111f){
-			player.stepHeight = 0.5f;
+			player.stepHeight = 0.6f;
 		}
 
 		IAttributeInstance attr = player.getEntityAttribute(SharedMonsterAttributes.MOVEMENT_SPEED);

--- a/src/main/java/am2/handler/PotionEffectHandler.java
+++ b/src/main/java/am2/handler/PotionEffectHandler.java
@@ -96,7 +96,7 @@ public class PotionEffectHandler {
 		if (e.getEntityLiving().isPotionActive(PotionEffectsDefs.agility)) {
 			e.getEntityLiving().stepHeight = 1.01f;
 		}else if (e.getEntityLiving().stepHeight == 1.01f) {
-			e.getEntityLiving().stepHeight = 0.5f;
+			e.getEntityLiving().stepHeight = 0.6f;
 		}
 	}
 	


### PR DESCRIPTION
Minecraft baseline stepheight is 0.6f now, not 0.5f.

I haven't actually run into these specific corner cases, but I stumbled across them while trying to find what mod was breaking stepheight. I figured we might as well fix them now before someone, uh, trips over them. So to speak.

(spoiler: it was botania.)
